### PR TITLE
wine.inf: set using opengl 4.6 for wined3d correctly

### DIFF
--- a/wine.inf
+++ b/wine.inf
@@ -3096,7 +3096,7 @@ HKLM,Software\NVIDIA Corporation\Global\NGXCore,"FullPath",,"C:\Windows\System32
 [ProtonOverrides]
 HKLM,Software\Khronos\OpenXR\1,"ActiveRuntime",,"C:\openxr\wineopenxr64.json"
 ;;Likely want *80 and *90 too, but those require removing Wine's manifest files.
-HKCU,Software\Wine\Direct3D,"MaxVersionGL",0x10001,"460"
+HKCU,Software\Wine\Direct3D,"MaxVersionGL",0x10001,"0x40006"
 HKCU,Software\Wine\Direct3D,"csmt",0x10001,"3"
 HKCU,Software\Wine\DllOverrides,"atl100",0x2,"native,builtin"
 HKCU,Software\Wine\DllOverrides,"msvcp100",0x2,"native,builtin"


### PR DESCRIPTION
Here according to this documentation: https://gitlab.winehq.org/wine/wine/-/wikis/Useful-Registry-Keys MaxVersionGL must be set as hexadecimal number: 0x40006

Also it can be confirmed if you put WINEDEBUG=+wined3d then in the logs you can see `err:winediag:wined3d_dll_init Setting maximum allowed wined3d GL version to 4.6.`