### PR TITLE
Update Proton-Tweaks and Enable them by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ These are the custom parameters introduced in Sarek to provide fallback renderin
 | `PROTON_VK_SOFTWARE=[0/1]`        | Uses Lavapipe for CPU-based rendering for Vulkan, supporting API version 1.3.                                                   |
 | `PROTON_OGL_SOFTWARE=[0/1]`       | Uses LLVMpipe for CPU-based rendering for OpenGL, supporting API version 4.6.                                                   |
 
-**Below are benchmarks comparing performance with** `PROTON_TWEAKS` **enabled and disabled:** 
+**Below are benchmarks comparing performance with the tweaks enabled and disabled:** 
 - [AMD Benchmark](https://flightlessmango.com/games/38020/logs/5865)
 - [NVIDIA Benchmark](https://flightlessmango.com/games/38020/logs/5863) (using proprietary drivers)
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Sarek (Proton-For-Old-Vulkan): A custom Proton build with DXVK 1.10.3 for users 
 
 **Why does this repository exist?**
 
-Because there are still users with GPUs that support Vulkan 1.1+ but not Vulkan 1.3, as well as others with non-Vulkan support. Those who can use DXVK often rely on older Proton versions, which suffer from lower compatibility and performance compared to newer builds. Meanwhile, users dependent on WineD3D frequently face poor gaming experiences. This repository provides patched versions of Proton and/or Proton-GE, offering better performance with DXVK v1.10.3 and WineD3D mainly through custom tweaks added to Proton, along with other enhancements, ensuring a smoother experience for both Vulkan and non-Vulkan setups.
+Because there are still users with GPUs that support Vulkan 1.1+ but not Vulkan 1.3, as well as others with non-Vulkan support. Those who can use DXVK often rely on older Proton versions, which suffer from lower compatibility and performance compared to newer builds. Meanwhile, users dependent on WineD3D frequently face poor gaming experiences. This repository provides patched versions of Proton and/or GE-Proton, offering better performance with DXVK v1.10.3 and WineD3D mainly through custom tweaks added to Proton, along with other enhancements, ensuring a smoother experience for both Vulkan and non-Vulkan setups.
 
 Please be aware that this is a custom build of Proton and is **not** affiliated with Valve's Proton. If you encounter any issues specific to my Proton build from this repository that do not occur with Valve's version, kindly refrain from submitting a bug report to Valve's bug GitHub. Instead, please report the issue directly on this GitHub. Thank you for your understanding!
 

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ These are the custom parameters introduced in Sarek to provide fallback renderin
 
 | Environment Variable              | Description                                                                                                                     |
 |-----------------------------------|---------------------------------------------------------------------------------------------------------------------------------|
-| `PROTON_DISABLE_TWEAKS=[0/1]`     | Disables all the tweaks added to Sarek for general performance optimization and restores it to the Default Proton Configuration |
+| `PROTON_NO_TWEAKS=[0/1]`     | Disables all the tweaks added to Sarek for general performance optimization and restores it to the Default Proton Configuration |
 | `PROTON_VK_SOFTWARE=[0/1]`        | Uses Lavapipe for CPU-based rendering for Vulkan, supporting API version 1.3.                                                   |
 | `PROTON_OGL_SOFTWARE=[0/1]`       | Uses LLVMpipe for CPU-based rendering for OpenGL, supporting API version 4.6.                                                   |
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Sarek (Proton-For-Old-Vulkan): A custom Proton build with DXVK 1.10.3 for users 
 
 **Why does this repository exist?**
 
-Because there are still users with GPUs that support Vulkan 1.1+ but not Vulkan 1.3, as well as others with non-Vulkan support. Those who can use DXVK often rely on older Proton versions, which suffer from lower compatibility and performance compared to newer builds. Meanwhile, users dependent on WineD3D frequently face poor gaming experiences. This repository provides patched versions of Proton and/or Proton-GE, offering better performance with DXVK v1.10.3 and WineD3D mainly trough the custom parameter `PROTON_TWEAKS`, along with other enhancements, ensuring a smoother experience for both Vulkan and non-Vulkan setups.
+Because there are still users with GPUs that support Vulkan 1.1+ but not Vulkan 1.3, as well as others with non-Vulkan support. Those who can use DXVK often rely on older Proton versions, which suffer from lower compatibility and performance compared to newer builds. Meanwhile, users dependent on WineD3D frequently face poor gaming experiences. This repository provides patched versions of Proton and/or Proton-GE, offering better performance with DXVK v1.10.3 and WineD3D mainly trough custom tweaks added to proton, along with other enhancements, ensuring a smoother experience for both Vulkan and non-Vulkan setups.
 
 Please be aware that this is a custom build of Proton and is **not** affiliated with Valve's Proton. If you encounter any issues specific to my Proton build from this repository that do not occur with Valve's version, kindly refrain from submitting a bug report to Valve's bug github. Instead, please report the issue directly on this GitHub. Thank you for your understanding!
 
@@ -127,16 +127,13 @@ First of all lets start with the must have, Gamemodem, Zram and MangoHud.
 My personal recomendation its to search a tutorial for the installation of the three in your favorite Linux Distro *;P*
 
 ### Sarek:
-These are the custom parameters introduced in Sarek to enhance performance and provide fallback rendering options.
+These are the custom parameters introduced in Sarek to provide fallback rendering options or controll over the build.
 
-| Environment Variable              | Description                                                                                                          |
-|-----------------------------------|----------------------------------------------------------------------------------------------------------------------|
-| `PROTON_TWEAKS=[0/1]`             | Enables all the `PROTON_TWEAKS_*` parameters for general performance optimization                                    |
-| `PROTON_TWEAKS_PROTON=[0/1]`      | Adds a set of Proton/Wine optimizations as environment variables                                                     |
-| `PROTON_TWEAKS_NVIDIA=[0/1]`      | Adds a set of optimizations for NVIDIA proprietary drivers                                                           |
-| `PROTON_TWEAKS_MESA=[0/1]`        | Adds a set of optimizations for MESA drivers                                                                         |
-| `PROTON_VK_SOFTWARE=[0/1]`        | Uses Lavapipe for CPU-based rendering for Vulkan, supporting API version 1.3, PROTON_TWEAKS comes enabled by default |
-| `PROTON_OGL_SOFTWARE=[0/1]`       | Uses LLVMpipe for CPU-based rendering for OpenGL, supporting API version 4.6, PROTON_TWEAKS comes enabled by default |
+| Environment Variable              | Description                                                                                                                     |
+|-----------------------------------|---------------------------------------------------------------------------------------------------------------------------------|
+| `PROTON_DISABLE_TWEAKS=[0/1]`     | Disables all the tweaks added to Sarek for general performance optimization and restores it to the Default Proton Configuration |
+| `PROTON_VK_SOFTWARE=[0/1]`        | Uses Lavapipe for CPU-based rendering for Vulkan, supporting API version 1.3.                                                   |
+| `PROTON_OGL_SOFTWARE=[0/1]`       | Uses LLVMpipe for CPU-based rendering for OpenGL, supporting API version 4.6.                                                   |
 
 **Below are benchmarks comparing performance with** `PROTON_TWEAKS` **enabled and disabled:** 
 - [AMD Benchmark](https://flightlessmango.com/games/38020/logs/5865)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Sarek (Proton-For-Old-Vulkan): A custom Proton build with DXVK 1.10.3 for users 
 
 **Why does this repository exist?**
 
-Because there are still users with GPUs that support Vulkan 1.1+ but not Vulkan 1.3, as well as others with non-Vulkan support. Those who can use DXVK often rely on older Proton versions, which suffer from lower compatibility and performance compared to newer builds. Meanwhile, users dependent on WineD3D frequently face poor gaming experiences. This repository provides patched versions of Proton and/or GE-Proton, offering better performance with DXVK v1.10.3 and WineD3D mainly through the custom parameter `PROTON_TWEAKS`, along with other enhancements, ensuring a smoother experience for both Vulkan and non-Vulkan setups.
+Because there are still users with GPUs that support Vulkan 1.1+ but not Vulkan 1.3, as well as others with non-Vulkan support. Those who can use DXVK often rely on older Proton versions, which suffer from lower compatibility and performance compared to newer builds. Meanwhile, users dependent on WineD3D frequently face poor gaming experiences. This repository provides patched versions of Proton and/or Proton-GE, offering better performance with DXVK v1.10.3 and WineD3D mainly through custom tweaks added to Proton, along with other enhancements, ensuring a smoother experience for both Vulkan and non-Vulkan setups.
 
 Please be aware that this is a custom build of Proton and is **not** affiliated with Valve's Proton. If you encounter any issues specific to my Proton build from this repository that do not occur with Valve's version, kindly refrain from submitting a bug report to Valve's bug GitHub. Instead, please report the issue directly on this GitHub. Thank you for your understanding!
 

--- a/Sarek-Patches/proton
+++ b/Sarek-Patches/proton
@@ -1613,7 +1613,7 @@ class Session:
         }
 
         # Apply Tweaks if wanted:
-        if "PROTON_DISABLE_TWEAKS" in self.env and nonzero(self.env["PROTON_DISABLE_TWEAKS"]) or "PROTON_LOG" in self.env and nonzero(self.env["PROTON_LOG"]):
+        if "PROTON_NO_TWEAKS" in self.env and nonzero(self.env["PROTON_NO_TWEAKS"]) or "PROTON_LOG" in self.env and nonzero(self.env["PROTON_LOG"]):
             pass
         else:
             self.env.update(proton_tweaks | nvidia_tweaks | mesa_tweaks)

--- a/Sarek-Patches/proton
+++ b/Sarek-Patches/proton
@@ -1574,12 +1574,6 @@ class Session:
             if self.env["PROTON_LOG"] != "1":
                 append_to_env_str(self.env, "WINEDEBUG", self.env["PROTON_LOG"], ",")
 
-        #for performance, logging is disabled by default; override with user_settings.py
-        self.env.setdefault("WINEDEBUG", "-all")
-        self.env.setdefault("DXVK_LOG_LEVEL", "none")
-        self.env.setdefault("VKD3D_DEBUG", "none")
-        self.env.setdefault("VKD3D_SHADER_DEBUG", "none")
-
         #disable XIM support until libx11 >= 1.7 is widespread
         self.env.setdefault("WINE_ALLOW_XIM", "0")
 
@@ -1589,13 +1583,9 @@ class Session:
         if "PROTON_OGL_SOFTWARE" in self.env and nonzero(self.env["PROTON_OGL_SOFTWARE"]):
             self.env["LIBGL_ALWAYS_SOFTWARE"] = "1"
             self.env["__GLX_VENDOR_LIBRARY_NAME"] = "mesa"
-            self.env["PROTON_TWEAKS_PROTON"] = "1"
-            self.env["PROTON_TWEAKS_MESA"] = "1"
 
         if "PROTON_VK_SOFTWARE" in self.env and nonzero(self.env["PROTON_VK_SOFTWARE"]):
             self.env["MESA_VK_DEVICE_SELECT"] = "10005:0!"
-            self.env["PROTON_TWEAKS_PROTON"] = "1"
-            self.env["PROTON_TWEAKS_MESA"] = "1"
 
         # Define tweak settings for Proton, NVIDIA, and Mesa:
         proton_tweaks = {
@@ -1603,20 +1593,12 @@ class Session:
             "DXVK_LOG_LEVEL": "none",
             "VKD3D_DEBUG": "none",
             "VKD3D_SHADER_DEBUG": "none",
-            "WINE_FULLSCREEN_FSR": "1",
-            "STAGING_WRITECOPY": "1",
-            "STAGING_SHARED_MEMORY": "1",
-            "PROTON_NO_WRITE_WATCH": "1",
-            "PROTON_FORCE_LARGE_ADDRESS_AWARE": "1",
         }
 
         nvidia_tweaks = {
             "__GL_THREADED_OPTIMIZATIONS": "1",
             "__GL_SHADER_DISK_CACHE": "1",
             "__GL_SHADER_DISK_CACHE_SIZE": "2147483648",
-            "__GL_SYNC_TO_VBLANK": "0",
-            "__GL_LOG_MAX_ANISO": "0",
-            "__GL_IGNORE_GLSL_EXT_REQS": "1",
             "__GL_YIELD": "NOTHING",
             "__GL_MaxFramesAllowed": "1",
         }
@@ -1625,28 +1607,16 @@ class Session:
             "mesa_glthread": "true",
             "MESA_SHADER_CACHE_DISABLE": "false",
             "MESA_SHADER_CACHE_MAX_SIZE": "2097152K",
-            "vblank_mode": "0",
-            "MESA_EXTENSION_OVERRIDE": "-GL_EXT_texture_filter_anisotropic",
-            "MESA_GL_VERSION_OVERRIDE": "4.6",
-            "MESA_GLSL_VERSION_OVERRIDE": "460",
             "MESA_NO_ERROR": "true",
             "MESA_DEBUG": "silent",
             "MESA_NO_DITHER": "1",
         }
 
         # Apply Tweaks if wanted:
-        if "PROTON_TWEAKS" in self.env and nonzero(self.env["PROTON_TWEAKS"]):
-            for tweak_flag in ["PROTON_TWEAKS_PROTON", "PROTON_TWEAKS_NVIDIA", "PROTON_TWEAKS_MESA"]:
-                self.env[tweak_flag] = "1"
-
-        if "PROTON_TWEAKS_PROTON" in self.env and nonzero(self.env["PROTON_TWEAKS_PROTON"]):
-            self.env.update(proton_tweaks)
-
-        if "PROTON_TWEAKS_NVIDIA" in self.env and nonzero(self.env["PROTON_TWEAKS_NVIDIA"]):
-            self.env.update(nvidia_tweaks)
-
-        if "PROTON_TWEAKS_MESA" in self.env and nonzero(self.env["PROTON_TWEAKS_MESA"]):
-            self.env.update(mesa_tweaks)
+        if "PROTON_DISABLE_TWEAKS" in self.env and nonzero(self.env["PROTON_DISABLE_TWEAKS"]) or "PROTON_LOG" in self.env and nonzero(self.env["PROTON_LOG"]):
+            pass
+        else:
+            self.env.update(proton_tweaks | nvidia_tweaks | mesa_tweaks)
 
         # <<Sarek Parameters>>
 

--- a/Sarek-Patches/proton-valve
+++ b/Sarek-Patches/proton-valve
@@ -1412,12 +1412,6 @@ class Session:
             if self.env["PROTON_LOG"] != "1":
                 append_to_env_str(self.env, "WINEDEBUG", self.env["PROTON_LOG"], ",")
 
-        #for performance, logging is disabled by default; override with user_settings.py
-        self.env.setdefault("WINEDEBUG", "-all")
-        self.env.setdefault("DXVK_LOG_LEVEL", "none")
-        self.env.setdefault("VKD3D_DEBUG", "none")
-        self.env.setdefault("VKD3D_SHADER_DEBUG", "none")
-
         #disable XIM support until libx11 >= 1.7 is widespread
         self.env.setdefault("WINE_ALLOW_XIM", "0")
 
@@ -1427,13 +1421,9 @@ class Session:
         if "PROTON_OGL_SOFTWARE" in self.env and nonzero(self.env["PROTON_OGL_SOFTWARE"]):
             self.env["LIBGL_ALWAYS_SOFTWARE"] = "1"
             self.env["__GLX_VENDOR_LIBRARY_NAME"] = "mesa"
-            self.env["PROTON_TWEAKS_PROTON"] = "1"
-            self.env["PROTON_TWEAKS_MESA"] = "1"
 
         if "PROTON_VK_SOFTWARE" in self.env and nonzero(self.env["PROTON_VK_SOFTWARE"]):
             self.env["MESA_VK_DEVICE_SELECT"] = "10005:0!"
-            self.env["PROTON_TWEAKS_PROTON"] = "1"
-            self.env["PROTON_TWEAKS_MESA"] = "1"
 
         # Define tweak settings for Proton, NVIDIA, and Mesa:
         proton_tweaks = {
@@ -1441,20 +1431,12 @@ class Session:
             "DXVK_LOG_LEVEL": "none",
             "VKD3D_DEBUG": "none",
             "VKD3D_SHADER_DEBUG": "none",
-            "WINE_FULLSCREEN_FSR": "1",
-            "STAGING_WRITECOPY": "1",
-            "STAGING_SHARED_MEMORY": "1",
-            "PROTON_NO_WRITE_WATCH": "1",
-            "PROTON_FORCE_LARGE_ADDRESS_AWARE": "1",
         }
 
         nvidia_tweaks = {
             "__GL_THREADED_OPTIMIZATIONS": "1",
             "__GL_SHADER_DISK_CACHE": "1",
             "__GL_SHADER_DISK_CACHE_SIZE": "2147483648",
-            "__GL_SYNC_TO_VBLANK": "0",
-            "__GL_LOG_MAX_ANISO": "0",
-            "__GL_IGNORE_GLSL_EXT_REQS": "1",
             "__GL_YIELD": "NOTHING",
             "__GL_MaxFramesAllowed": "1",
         }
@@ -1463,28 +1445,16 @@ class Session:
             "mesa_glthread": "true",
             "MESA_SHADER_CACHE_DISABLE": "false",
             "MESA_SHADER_CACHE_MAX_SIZE": "2097152K",
-            "vblank_mode": "0",
-            "MESA_EXTENSION_OVERRIDE": "-GL_EXT_texture_filter_anisotropic",
-            "MESA_GL_VERSION_OVERRIDE": "4.6",
-            "MESA_GLSL_VERSION_OVERRIDE": "460",
             "MESA_NO_ERROR": "true",
             "MESA_DEBUG": "silent",
             "MESA_NO_DITHER": "1",
         }
 
         # Apply Tweaks if wanted:
-        if "PROTON_TWEAKS" in self.env and nonzero(self.env["PROTON_TWEAKS"]):
-            for tweak_flag in ["PROTON_TWEAKS_PROTON", "PROTON_TWEAKS_NVIDIA", "PROTON_TWEAKS_MESA"]:
-                self.env[tweak_flag] = "1"
-
-        if "PROTON_TWEAKS_PROTON" in self.env and nonzero(self.env["PROTON_TWEAKS_PROTON"]):
-            self.env.update(proton_tweaks)
-
-        if "PROTON_TWEAKS_NVIDIA" in self.env and nonzero(self.env["PROTON_TWEAKS_NVIDIA"]):
-            self.env.update(nvidia_tweaks)
-
-        if "PROTON_TWEAKS_MESA" in self.env and nonzero(self.env["PROTON_TWEAKS_MESA"]):
-            self.env.update(mesa_tweaks)
+        if "PROTON_DISABLE_TWEAKS" in self.env and nonzero(self.env["PROTON_DISABLE_TWEAKS"]) or "PROTON_LOG" in self.env and nonzero(self.env["PROTON_LOG"]):
+            pass
+        else:
+            self.env.update(proton_tweaks | nvidia_tweaks | mesa_tweaks)
 
         # <<Sarek Parameters>>
 

--- a/Sarek-Patches/proton-valve
+++ b/Sarek-Patches/proton-valve
@@ -1451,7 +1451,7 @@ class Session:
         }
 
         # Apply Tweaks if wanted:
-        if "PROTON_DISABLE_TWEAKS" in self.env and nonzero(self.env["PROTON_DISABLE_TWEAKS"]) or "PROTON_LOG" in self.env and nonzero(self.env["PROTON_LOG"]):
+        if "PROTON_NO_TWEAKS" in self.env and nonzero(self.env["PROTON_NO_TWEAKS"]) or "PROTON_LOG" in self.env and nonzero(self.env["PROTON_LOG"]):
             pass
         else:
             self.env.update(proton_tweaks | nvidia_tweaks | mesa_tweaks)


### PR DESCRIPTION
This pull request updates Proton-Tweaks to enable them by default, aiming to improve performance on OpenGL/WineD3D and enhance a little the shader cache management for both OpenGL and Vulkan on low end hardware. This change is currently under testing to identify any potential regressions in performance or compatibility.